### PR TITLE
Introduce `--force` option to always process large number of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The ``ec`` binary supports the following options:
 | ``--verbose``              | ``-v``   | Shows additional informations, like detailed info about internal time tracking and which binary files have been skipped.                                                            |
 | ``--no-interaction``       | ``-n``   | Do not ask for confirmation, if more than 500 files found.                                                                                                                          |
 | ``--no-error-on-exit``     |          | By default ``ec`` returns code 2 when issues occurred. With this option set return code is always 0.                                                                                |
+| ``--force``                |          | When set, files are always processed even if more than 500 files were found.                                                                                                        |
 
 **Tip:** The "usage" section on ``ec``'s help page shows some examples.
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -79,6 +79,7 @@ class Application extends SingleCommandApplication
             ->addOption('uncovered', 'u', InputOption::VALUE_NONE, 'When set, all files which are not covered by .editorconfig get listed')
             ->addOption('no-progress', '', InputOption::VALUE_NONE, 'When set, no progress indicator is displayed')
             ->addOption('no-error-on-exit', '', InputOption::VALUE_NONE, 'When set, the CLI tool will always return code 0, also when issues have been found')
+            ->addOption('force', '', InputOption::VALUE_NONE, 'When set, files are always processed even if more than 500 files were found')
             ->setCode([$this, 'executing'])
         ;
     }
@@ -178,7 +179,7 @@ class Application extends SingleCommandApplication
             return $returnValue; // Early return
         }
 
-        if ($count > 500 && !$input->getOption('no-interaction') && !$io->confirm('Continue?', false)) {
+        if ($count > 500 && !$input->getOption('force') && !$input->getOption('no-interaction') && !$io->confirm('Continue?', false)) {
             // @codeCoverageIgnoreStart
             $io->writeln('Canceled.');
 


### PR DESCRIPTION
This PR adds a new command option `--force`. It skips the confirmation dialog if more than 500 files were found and continues processing all found files. This behavior is different from the `--no-interation` command option where further processing is canceled.

The new option may especially be useful in CI context, where processing a large number of files may be okay.