### PR TITLE
[FEATURE] Add support for Symfony 7 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         "php": "^7.4 | ^8.0",
         "ext-json": "*",
         "ext-iconv": "*",
-        "symfony/console": "^4 || ^5 || ^6",
-        "symfony/finder": "^4.4 || ^5 || ^6",
+        "symfony/console": "^4 || ^5 || ^6 || ^7",
+        "symfony/finder": "^4.4 || ^5 || ^6 || ^7",
         "idiosyncratic/editorconfig": "^0.1.1",
-        "symfony/mime": "^4 || ^5 || ^6"
+        "symfony/mime": "^4 || ^5 || ^6 || ^7"
     },
     "require-dev": {
         "seld/phar-utils": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a68da3db6d6727dbb186c4c9d5bb0f0",
+    "content-hash": "f192853513a1bc95c7ebc82bb344d6d9",
     "packages": [
         {
             "name": "idiosyncratic/editorconfig",


### PR DESCRIPTION
This PR adds support for Symfony 7 components.

Unfortunately, I couldn't update the locked dependencies to Symfony 7, because `friendsofphp/php-cs-fixer` is currently locked to `3.4.0`, which is not compatible with Symfony 7. I wasn't sure if it's desired if this dependency is updated as well, that's why I haven't touched it and therefore locked dependencies stay the same.

How should we continue here? Bump `friendsofphp/php-cs-fixer` to a version compatible with Symfony 7 and fix all CGL issues related to the update?