### PR TITLE
[TASK] Exclude development-only files from dist archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 /.build export-ignore
 /.ddev export-ignore
 /.github export-ignore
+/src/Compiler.php export-ignore
 /tests export-ignore
 /.editorconfig export-ignore
 /.gitattributes export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/.build export-ignore
+/.ddev export-ignore
+/.github export-ignore
+/tests export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/composer.lock export-ignore


### PR DESCRIPTION
This PR adds a `.gitattributes` file which contains rules to exclude several development-only files and folders from being packaged into dist archives. This way, those files will not be existent when e.g. requiring the library with Composer's default installation method (`"preferred-install": "dist"`).