### PR TITLE
[TASK] Add PHP 8.4 to test matrix and update to PHPStan v2

### DIFF
--- a/.build/php-cs-rules.php
+++ b/.build/php-cs-rules.php
@@ -9,6 +9,7 @@ $finder = PhpCsFixer\Finder::create()
 ;
 
 return (new PhpCsFixer\Config())
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRiskyAllowed(true)
     ->setCacheFile(__DIR__ . '/.php-cs-fixer.cache')
     ->setRules([

--- a/.build/phpstan.neon
+++ b/.build/phpstan.neon
@@ -6,5 +6,4 @@ parameters:
     paths:
         - ../src
     excludePaths:
-        - ../src/Compatibility
         - ../src/Compiler.php

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: "shivammathur/setup-php@v2"
@@ -34,7 +34,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.dependencies }}
@@ -42,7 +42,7 @@ jobs:
           ${{ runner.os }}-php-
 
     - name: Composer install
-      uses: "ramsey/composer-install@v1"
+      uses: ramsey/composer-install@v3
       with:
         dependency-versions: "${{ matrix.dependencies }}"
         composer-options: "${{ matrix.composer-options }}"
@@ -54,7 +54,7 @@ jobs:
       run: composer run-script test-with-coverage
 
     - name: Upload test reports artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test-reports-${{ matrix.php }}-${{ matrix.dependencies }}
         path: |

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -14,6 +14,7 @@ jobs:
         php:
           - "8.2"
           - "8.3"
+          - "8.4"
         dependencies:
           - "lowest"
           - "highest"
@@ -51,7 +52,6 @@ jobs:
 
     - name: Run test suite
       run: composer run-script test-with-coverage
-      if: ${{ matrix.php != '8.1' }}
 
     - name: Upload test reports artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: "ubuntu-latest"
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
 
         - name: Setup PHP
           uses: "shivammathur/setup-php@v2"
@@ -24,7 +24,7 @@ jobs:
 
         - name: Cache Composer packages
           id: composer-cache
-          uses: actions/cache@v2
+          uses: actions/cache@v4
           with:
             path: vendor
             key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -32,7 +32,7 @@ jobs:
                 ${{ runner.os }}-php-
 
         - name: Composer install
-          uses: "ramsey/composer-install@v1"
+          uses: ramsey/composer-install@v3
 
         - name: Get latest release version number
           id: get_version

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Written by **Armin Vieweg**  <<https://v.ieweg.de>>
 
 ## Requirements
 
-- PHP 8.2 or 8.3
+- PHP 8.2, 8.3 or 8.4
 - Enabled PHP extensions: iconv, json
 
 If you are looking for older PHP version support, you can check out and use those tags:

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     },
     "require-dev": {
         "seld/phar-utils": "^1.2",
-        "phpstan/phpstan": "^1.11",
-        "jangregor/phpstan-prophecy": "^1.0",
+        "phpstan/phpstan": "^2.0",
+        "jangregor/phpstan-prophecy": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.59",
         "phpunit/phpunit": "^10.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "195ead850f2dc9db7793b4ce336c76f6",
+    "content-hash": "24f31a8fc4963b20fb5a4393b0aabc27",
     "packages": [
         {
             "name": "idiosyncratic/editorconfig",
@@ -1558,32 +1558,34 @@
         },
         {
             "name": "jangregor/phpstan-prophecy",
-            "version": "1.0.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Jan0707/phpstan-prophecy.git",
-                "reference": "5ee56c7db1d58f0578c82a35e3c1befe840e85a9"
+                "reference": "8937c0f084eefb928032b438f0f57ad5cba3dbdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Jan0707/phpstan-prophecy/zipball/5ee56c7db1d58f0578c82a35e3c1befe840e85a9",
-                "reference": "5ee56c7db1d58f0578c82a35e3c1befe840e85a9",
+                "url": "https://api.github.com/repos/Jan0707/phpstan-prophecy/zipball/8937c0f084eefb928032b438f0f57ad5cba3dbdc",
+                "reference": "8937c0f084eefb928032b438f0f57ad5cba3dbdc",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0",
-                "phpstan/phpstan": "^1.0.0"
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.0.0"
             },
             "conflict": {
-                "phpspec/prophecy": "<1.7.0 || >=2.0.0",
-                "phpunit/phpunit": "<6.0.0 || >=12.0.0"
+                "phpspec/prophecy": "<1.17.0 || >=2.0.0",
+                "phpspec/prophecy-phpunit": "<2.3.0 || >=3.0.0",
+                "phpunit/phpunit": "<9.1.0 || >=12.0.0"
             },
             "require-dev": {
                 "ergebnis/composer-normalize": "^2.1.1",
-                "ergebnis/license": "^1.0.0",
-                "ergebnis/php-cs-fixer-config": "~2.2.0",
+                "ergebnis/license": "^2.6.0",
+                "ergebnis/php-cs-fixer-config": "^4.0 || ^5.0 || ^6.0",
                 "phpspec/prophecy": "^1.7.0",
-                "phpunit/phpunit": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+                "phpspec/prophecy-phpunit": "^2.3",
+                "phpunit/phpunit": "^9.1.0"
             },
             "type": "phpstan-extension",
             "extra": {
@@ -1611,9 +1613,9 @@
             "description": "Provides a phpstan/phpstan extension for phpspec/prophecy",
             "support": {
                 "issues": "https://github.com/Jan0707/phpstan-prophecy/issues",
-                "source": "https://github.com/Jan0707/phpstan-prophecy/tree/1.0.2"
+                "source": "https://github.com/Jan0707/phpstan-prophecy/tree/2.0.0"
             },
-            "time": "2024-04-03T08:15:54+00:00"
+            "time": "2024-11-21T13:41:50+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1853,20 +1855,20 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.7",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "52d2bbfdcae7f895915629e4694e9497d0f8e28d"
+                "reference": "6c98c7600fc717b2c78c11ef60040d5b1e359c82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/52d2bbfdcae7f895915629e4694e9497d0f8e28d",
-                "reference": "52d2bbfdcae7f895915629e4694e9497d0f8e28d",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6c98c7600fc717b2c78c11ef60040d5b1e359c82",
+                "reference": "6c98c7600fc717b2c78c11ef60040d5b1e359c82",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -1907,7 +1909,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-06T11:17:41+00:00"
+            "time": "2024-11-17T14:17:00+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4546,7 +4548,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -4554,6 +4556,6 @@
         "ext-json": "*",
         "ext-iconv": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/docs/Contribute.md
+++ b/docs/Contribute.md
@@ -70,6 +70,8 @@ Also, each build will run on the following combinations of PHP version and Compo
 - PHP 8.2, Highest
 - PHP 8.3, Lowest
 - PHP 8.3, Highest
+- PHP 8.4, Lowest
+- PHP 8.4, Highest
 
 *Note:* "Highest" is the default behaviour of Composer.
         "Lowest" is when you run Composer update with ``--prefer-lowest``

--- a/src/Application.php
+++ b/src/Application.php
@@ -120,7 +120,6 @@ class Application extends SingleCommandApplication
 
         $finderConfigPath = null;
         if (!empty($input->getOption('finder-config'))) {
-            /** @var string $finderConfigPath */
             $finderConfigPath = $input->getOption('finder-config');
             $finderConfigPath = $realPath . '/' . $finderConfigPath;
             $finder = FinderUtility::loadCustomFinderInstance($finderConfigPath, $finderOptions);

--- a/src/EditorConfig/Rules/Validator.php
+++ b/src/EditorConfig/Rules/Validator.php
@@ -19,7 +19,7 @@ use Symfony\Component\Finder\SplFileInfo;
 class Validator
 {
     /**
-     * @var Declaration[]
+     * @var array<string, Declaration>
      */
     private array $editorConfig;
 
@@ -108,7 +108,6 @@ class Validator
     {
         return !in_array($ruleName, $this->skippingRules, true)
             && isset($this->editorConfig[$ruleName])
-            && $this->editorConfig[$ruleName] instanceof Declaration
             && ($this->editorConfig[$ruleName]->getValue() || $this->editorConfig[$ruleName]->getStringValue());
     }
 }

--- a/tests/Functional/EditorConfig/CommandGitUnavailableFilesTest.php
+++ b/tests/Functional/EditorConfig/CommandGitUnavailableFilesTest.php
@@ -18,7 +18,7 @@ TXT;
 
     public function setUp(): void
     {
-        $this->workspacePath = sys_get_temp_dir() . '/current_editorconfig_cli_test';
+        $this->workspacePath = realpath(sys_get_temp_dir()) . '/current_editorconfig_cli_test';
 
         parent::setUp();
 


### PR DESCRIPTION
This PR

- [x] adds PHP 8.4 to test matrix and declares PHP 8.4 support in README
- [x] updates codebase for compatibility with PHPStan v2 
- [x] enables parallel runs in PHP-CS-Fixer
- [x] updates GitHub Actions to latest versions